### PR TITLE
fix compile error in goas/v3/logger

### DIFF
--- a/v3/logger/doc.go
+++ b/v3/logger/doc.go
@@ -9,6 +9,8 @@
 // way to log information with different levels and on different backends.
 package logger
 
+import "github.com/tideland/goas/v1/version"
+
 //--------------------
 // VERSION
 //--------------------

--- a/v3/logger/logger.go
+++ b/v3/logger/logger.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/tideland/goas/v1/version"
 )
 
 //--------------------


### PR DESCRIPTION
There was a change (3d1db8b3) that moved the `PackageVersion()` function from `v3/logger/logger.go` to `v3/logger/doc.go`. Unfortunately, the import for the `version` package was not moved thus causing a compile error.

This should fix that.